### PR TITLE
Update Sparepart API

### DIFF
--- a/__tests__/unit/controllers/sparepart/add-sparepart.controller.unit.test.tsx
+++ b/__tests__/unit/controllers/sparepart/add-sparepart.controller.unit.test.tsx
@@ -1,0 +1,153 @@
+import { Request, Response } from "express";
+import SparepartController from "../../../../src/controllers/sparepart.controller";
+import SparepartService from "../../../../src/services/sparepart.service";
+import { SparepartsDTO } from "../../../../src/dto/sparepart.dto";
+import { validationResult } from "express-validator";
+
+// Mock express-validator
+jest.mock("express-validator", () => ({
+  validationResult: jest.fn(),
+}));
+
+// Mock SparepartService
+jest.mock("../../../../src/services/sparepart.service");
+
+describe("SparepartController - ADD", () => {
+  let sparepartController: SparepartController;
+  let mockSparepartService: jest.Mocked<SparepartService>;
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let jsonMock: jest.Mock;
+  let statusMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Setup mock service
+    mockSparepartService =
+      new SparepartService() as jest.Mocked<SparepartService>;
+    sparepartController = new SparepartController();
+    (sparepartController as any).sparepartService = mockSparepartService;
+
+    // Setup mock request and response
+    jsonMock = jest.fn().mockReturnThis();
+    statusMock = jest.fn().mockReturnValue({ json: jsonMock });
+
+    mockRequest = {};
+    mockResponse = {
+      status: statusMock,
+      json: jsonMock,
+    };
+
+    // Setup validation result mock
+    (validationResult as unknown as jest.Mock).mockReturnValue({
+      isEmpty: jest.fn().mockReturnValue(true),
+      array: jest.fn().mockReturnValue([]),
+    });
+  });
+
+  describe("addSparepart", () => {
+    it("should add a sparepart successfully", async () => {
+      const mockSparepartData: SparepartsDTO = {
+        partsName: "Test Part",
+        purchaseDate: new Date("2023-01-01"),
+        price: 100,
+        toolLocation: "Warehouse A",
+        toolDate: "2023-01-05",
+        createdBy: 1,
+      } as SparepartsDTO;
+
+      const mockCreatedSparepart: SparepartsDTO = {
+        ...mockSparepartData,
+        id: "mock-uuid",
+        createdOn: new Date(),
+        modifiedOn: new Date(),
+      };
+
+      mockRequest.body = mockSparepartData;
+      mockSparepartService.addSparepart = jest
+        .fn()
+        .mockResolvedValue(mockCreatedSparepart);
+
+      await sparepartController.addSparepart(
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(validationResult).toHaveBeenCalledWith(mockRequest);
+      expect(mockSparepartService.addSparepart).toHaveBeenCalledWith(
+        mockSparepartData,
+      );
+      expect(statusMock).toHaveBeenCalledWith(201);
+      expect(jsonMock).toHaveBeenCalledWith(mockCreatedSparepart);
+    });
+
+    it("should return 400 if validation fails", async () => {
+      const validationErrors = [{ msg: "partsName is required" }];
+
+      (validationResult as unknown as jest.Mock).mockReturnValue({
+        isEmpty: jest.fn().mockReturnValue(false),
+        array: jest.fn().mockReturnValue(validationErrors),
+      });
+
+      await sparepartController.addSparepart(
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(validationResult).toHaveBeenCalledWith(mockRequest);
+      expect(mockSparepartService.addSparepart).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith({ errors: validationErrors });
+    });
+
+    it("should return 500 if service throws an error", async () => {
+      const errorMessage = "Service error";
+      mockRequest.body = { partsName: "Test Part", createdBy: 1 };
+
+      mockSparepartService.addSparepart = jest
+        .fn()
+        .mockRejectedValue(new Error(errorMessage));
+
+      await sparepartController.addSparepart(
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(validationResult).toHaveBeenCalledWith(mockRequest);
+      expect(mockSparepartService.addSparepart).toHaveBeenCalledWith(
+        mockRequest.body,
+      );
+      expect(statusMock).toHaveBeenCalledWith(500);
+      expect(jsonMock).toHaveBeenCalledWith({ error: errorMessage });
+    });
+
+    it("should pass all request body data to service", async () => {
+      const mockSparepartData: SparepartsDTO = {
+        partsName: "Test Part",
+        purchaseDate: new Date("2023-01-01"),
+        price: 100,
+        toolLocation: "Warehouse A",
+        toolDate: "2023-01-05",
+        createdBy: 1,
+      } as SparepartsDTO;
+
+      mockRequest.body = mockSparepartData;
+      mockSparepartService.addSparepart = jest.fn().mockResolvedValue({
+        ...mockSparepartData,
+        id: "mock-uuid",
+        createdOn: new Date(),
+        modifiedOn: new Date(),
+      });
+
+      await sparepartController.addSparepart(
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(mockSparepartService.addSparepart).toHaveBeenCalledWith(
+        mockSparepartData,
+      );
+    });
+  });
+});

--- a/__tests__/unit/controllers/sparepart/delete-sparepart.controller.unit.test.tsx
+++ b/__tests__/unit/controllers/sparepart/delete-sparepart.controller.unit.test.tsx
@@ -1,0 +1,146 @@
+import { Request, Response } from "express";
+import SparepartController from "../../../../src/controllers/sparepart.controller";
+import SparepartService from "../../../../src/services/sparepart.service";
+import { SparepartsDTO } from "../../../../src/dto/sparepart.dto";
+
+// Mock SparepartService
+jest.mock("../../../../src/services/sparepart.service");
+
+describe("SparepartController - DELETE", () => {
+  let sparepartController: SparepartController;
+  let mockSparepartService: jest.Mocked<SparepartService>;
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let jsonMock: jest.Mock;
+  let statusMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Setup mock service
+    mockSparepartService =
+      new SparepartService() as jest.Mocked<SparepartService>;
+    sparepartController = new SparepartController();
+    (sparepartController as any).sparepartService = mockSparepartService;
+
+    // Setup mock request and response
+    jsonMock = jest.fn().mockReturnThis();
+    statusMock = jest.fn().mockReturnValue({ json: jsonMock });
+
+    mockRequest = {
+      params: { id: "1" },
+    };
+    mockResponse = {
+      status: statusMock,
+      json: jsonMock,
+    };
+  });
+
+  describe("deleteSparepart", () => {
+    it("should delete a sparepart successfully", async () => {
+      const mockDeletedSparepart: SparepartsDTO = {
+        id: "1",
+        partsName: "Test Part",
+        purchaseDate: new Date("2023-01-01"),
+        price: 100,
+        toolLocation: "Warehouse A",
+        toolDate: "2023-01-05",
+        createdBy: 1,
+        createdOn: new Date("2023-01-01"),
+        modifiedOn: new Date("2023-01-01"),
+        deletedOn: new Date(),
+      } as SparepartsDTO;
+
+      mockSparepartService.deleteSparepart = jest
+        .fn()
+        .mockResolvedValue(mockDeletedSparepart);
+
+      await sparepartController.deleteSparepart(
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(mockSparepartService.deleteSparepart).toHaveBeenCalledWith("1");
+      expect(statusMock).toHaveBeenCalledWith(200);
+      expect(jsonMock).toHaveBeenCalledWith({
+        message: "Sparepart deleted successfully",
+      });
+    });
+
+    it("should return 404 if sparepart not found", async () => {
+      mockSparepartService.deleteSparepart = jest.fn().mockResolvedValue(null);
+
+      await sparepartController.deleteSparepart(
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(mockSparepartService.deleteSparepart).toHaveBeenCalledWith("1");
+      expect(statusMock).toHaveBeenCalledWith(404);
+      expect(jsonMock).toHaveBeenCalledWith({ message: "Sparepart not found" });
+    });
+
+    it("should return 500 if service throws an error", async () => {
+      const errorMessage = "Service error";
+      mockSparepartService.deleteSparepart = jest
+        .fn()
+        .mockRejectedValue(new Error(errorMessage));
+
+      await sparepartController.deleteSparepart(
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(mockSparepartService.deleteSparepart).toHaveBeenCalledWith("1");
+      expect(statusMock).toHaveBeenCalledWith(500);
+      expect(jsonMock).toHaveBeenCalledWith({ message: errorMessage });
+    });
+
+    it("should use the id from request params", async () => {
+      mockRequest.params = { id: "custom-id-123" };
+      mockSparepartService.deleteSparepart = jest
+        .fn()
+        .mockResolvedValue({} as SparepartsDTO);
+
+      await sparepartController.deleteSparepart(
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(mockSparepartService.deleteSparepart).toHaveBeenCalledWith(
+        "custom-id-123",
+      );
+    });
+
+    it("should return success message even if service returns sparepart data", async () => {
+      const mockDeletedSparepart: SparepartsDTO = {
+        id: "1",
+        partsName: "Test Part",
+        purchaseDate: new Date("2023-01-01"),
+        price: 100,
+        toolLocation: "Warehouse A",
+        toolDate: "2023-01-05",
+        createdBy: 1,
+        createdOn: new Date("2023-01-01"),
+        modifiedOn: new Date("2023-01-01"),
+        deletedOn: new Date(),
+      } as SparepartsDTO;
+
+      mockSparepartService.deleteSparepart = jest
+        .fn()
+        .mockResolvedValue(mockDeletedSparepart);
+
+      await sparepartController.deleteSparepart(
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(statusMock).toHaveBeenCalledWith(200);
+      expect(jsonMock).toHaveBeenCalledWith({
+        message: "Sparepart deleted successfully",
+      });
+      // Not returning the actual deleted sparepart data
+      expect(jsonMock).not.toHaveBeenCalledWith(mockDeletedSparepart);
+    });
+  });
+});

--- a/__tests__/unit/controllers/sparepart/update-sparepart.controller.unit.test.tsx
+++ b/__tests__/unit/controllers/sparepart/update-sparepart.controller.unit.test.tsx
@@ -1,0 +1,149 @@
+import { Request, Response } from "express";
+import SparepartController from "../../../../src/controllers/sparepart.controller";
+import SparepartService from "../../../../src/services/sparepart.service";
+import { SparepartsDTO } from "../../../../src/dto/sparepart.dto";
+
+// Mock SparepartService
+jest.mock("../../../../src/services/sparepart.service");
+
+describe("SparepartController - UPDATE", () => {
+  let sparepartController: SparepartController;
+  let mockSparepartService: jest.Mocked<SparepartService>;
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let jsonMock: jest.Mock;
+  let statusMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Setup mock service
+    mockSparepartService =
+      new SparepartService() as jest.Mocked<SparepartService>;
+    sparepartController = new SparepartController();
+    (sparepartController as any).sparepartService = mockSparepartService;
+
+    // Setup mock request and response
+    jsonMock = jest.fn().mockReturnThis();
+    statusMock = jest.fn().mockReturnValue({ json: jsonMock });
+
+    mockRequest = {
+      params: { id: "1" },
+      body: {},
+    };
+    mockResponse = {
+      status: statusMock,
+      json: jsonMock,
+    };
+  });
+
+  describe("updateSparepart", () => {
+    it("should update a sparepart successfully", async () => {
+      const mockUpdateData: Partial<SparepartsDTO> = {
+        partsName: "Updated Part",
+        price: 150,
+        modifiedBy: 2,
+      };
+
+      const mockUpdatedSparepart: SparepartsDTO = {
+        id: "1",
+        partsName: "Updated Part",
+        purchaseDate: new Date("2023-01-01"),
+        price: 150,
+        toolLocation: "Warehouse A",
+        toolDate: "2023-01-05",
+        createdBy: 1,
+        createdOn: new Date("2023-01-01"),
+        modifiedBy: 2,
+        modifiedOn: new Date(),
+      } as SparepartsDTO;
+
+      mockRequest.body = mockUpdateData;
+      mockSparepartService.updateSparepart = jest
+        .fn()
+        .mockResolvedValue(mockUpdatedSparepart);
+
+      await sparepartController.updateSparepart(
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(mockSparepartService.updateSparepart).toHaveBeenCalledWith(
+        "1",
+        mockUpdateData,
+      );
+      expect(statusMock).toHaveBeenCalledWith(200);
+      expect(jsonMock).toHaveBeenCalledWith(mockUpdatedSparepart);
+    });
+
+    it("should return 404 if sparepart not found or data is invalid", async () => {
+      mockRequest.body = { partsName: "Updated Part", modifiedBy: 2 };
+      mockSparepartService.updateSparepart = jest.fn().mockResolvedValue(null);
+
+      await sparepartController.updateSparepart(
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(mockSparepartService.updateSparepart).toHaveBeenCalledWith(
+        "1",
+        mockRequest.body,
+      );
+      expect(statusMock).toHaveBeenCalledWith(404);
+      expect(jsonMock).toHaveBeenCalledWith({
+        message: "Sparepart not found or invalid data",
+      });
+    });
+
+    it("should return 500 if service throws an error", async () => {
+      const errorMessage = "Service error";
+      mockRequest.body = { partsName: "Updated Part", modifiedBy: 2 };
+
+      mockSparepartService.updateSparepart = jest
+        .fn()
+        .mockRejectedValue(new Error(errorMessage));
+
+      await sparepartController.updateSparepart(
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(mockSparepartService.updateSparepart).toHaveBeenCalledWith(
+        "1",
+        mockRequest.body,
+      );
+      expect(statusMock).toHaveBeenCalledWith(500);
+      expect(jsonMock).toHaveBeenCalledWith({ message: errorMessage });
+    });
+
+    it("should pass all request body data to service", async () => {
+      const mockUpdateData: Partial<SparepartsDTO> = {
+        partsName: "Updated Part",
+        price: 150,
+        toolLocation: "New Location",
+        toolDate: "2023-02-05",
+        modifiedBy: 2,
+      };
+
+      mockRequest.body = mockUpdateData;
+      mockSparepartService.updateSparepart = jest.fn().mockResolvedValue({
+        id: "1",
+        ...mockUpdateData,
+        purchaseDate: new Date("2023-01-01"),
+        createdBy: 1,
+        createdOn: new Date("2023-01-01"),
+        modifiedOn: new Date(),
+      });
+
+      await sparepartController.updateSparepart(
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(mockSparepartService.updateSparepart).toHaveBeenCalledWith(
+        "1",
+        mockUpdateData,
+      );
+    });
+  });
+});

--- a/__tests__/unit/repository/sparepart/add-sparepart.repository-unit.test.tsx
+++ b/__tests__/unit/repository/sparepart/add-sparepart.repository-unit.test.tsx
@@ -1,0 +1,111 @@
+import { PrismaClient } from "@prisma/client";
+import SparepartRepository from "../../../../src/repository/sparepart.repository";
+import { SparepartsDTO } from "../../../../src/dto/sparepart.dto";
+import prisma from "../../../../src/configs/db.config";
+
+// Mock the Prisma client
+jest.mock("../../../../src/configs/db.config", () => {
+  return {
+    __esModule: true,
+    default: {
+      spareparts: {
+        create: jest.fn(),
+      },
+    },
+  };
+});
+
+describe("SparepartRepository - CREATE", () => {
+  let sparepartRepository: SparepartRepository;
+  let mockPrisma: jest.Mocked<PrismaClient>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPrisma = prisma as unknown as jest.Mocked<PrismaClient>;
+    sparepartRepository = new SparepartRepository();
+  });
+
+  describe("createSparepart", () => {
+    it("should create a new sparepart successfully", async () => {
+      const mockSparepartData: SparepartsDTO = {
+        id: "mock-id",
+        partsName: "Test Part",
+        purchaseDate: new Date("2023-01-01"),
+        price: 100,
+        toolLocation: "Warehouse A",
+        toolDate: "2023-01-05", // toolDate as string
+        createdBy: 1,
+        createdOn: new Date("2023-01-01"),
+        modifiedOn: new Date("2023-01-01"),
+      };
+
+      (mockPrisma.spareparts.create as jest.Mock).mockResolvedValue(
+        mockSparepartData,
+      );
+
+      const result =
+        await sparepartRepository.createSparepart(mockSparepartData);
+
+      expect(mockPrisma.spareparts.create).toHaveBeenCalledWith({
+        data: mockSparepartData,
+      });
+      expect(result).toEqual(mockSparepartData);
+    });
+
+    it("should handle errors when creating a sparepart", async () => {
+      const mockSparepartData: SparepartsDTO = {
+        id: "mock-id",
+        partsName: "Test Part",
+        purchaseDate: new Date("2023-01-01"),
+        price: 100,
+        toolLocation: "Warehouse A",
+        toolDate: "2023-01-05", // toolDate as string
+        createdBy: 1,
+        createdOn: new Date("2023-01-01"),
+        modifiedOn: new Date("2023-01-01"),
+      };
+
+      const errorMessage = "Database error";
+      (mockPrisma.spareparts.create as jest.Mock).mockRejectedValue(
+        new Error(errorMessage),
+      );
+
+      await expect(
+        sparepartRepository.createSparepart(mockSparepartData),
+      ).rejects.toThrow(errorMessage);
+      expect(mockPrisma.spareparts.create).toHaveBeenCalledWith({
+        data: mockSparepartData,
+      });
+    });
+
+    it("should create a sparepart with minimal required fields", async () => {
+      const minimalSparepartData = {
+        id: "minimal-id",
+        partsName: "Minimal Part",
+        createdBy: 1,
+      };
+
+      const expectedResponse = {
+        ...minimalSparepartData,
+        purchaseDate: null,
+        price: null,
+        toolLocation: null,
+        toolDate: null,
+        createdOn: expect.any(Date),
+        modifiedOn: expect.any(Date),
+      };
+
+      (mockPrisma.spareparts.create as jest.Mock).mockResolvedValue(
+        expectedResponse,
+      );
+
+      const result =
+        await sparepartRepository.createSparepart(minimalSparepartData);
+
+      expect(mockPrisma.spareparts.create).toHaveBeenCalledWith({
+        data: minimalSparepartData,
+      });
+      expect(result).toEqual(expectedResponse);
+    });
+  });
+});

--- a/__tests__/unit/repository/sparepart/delete-sparepart.repository-unit.test.tsx
+++ b/__tests__/unit/repository/sparepart/delete-sparepart.repository-unit.test.tsx
@@ -1,0 +1,110 @@
+import { PrismaClient } from "@prisma/client";
+import SparepartRepository from "../../../../src/repository/sparepart.repository";
+import { SparepartsDTO } from "../../../../src/dto/sparepart.dto";
+import prisma from "../../../../src/configs/db.config";
+
+// Mock the Prisma client
+jest.mock("../../../../src/configs/db.config", () => {
+  return {
+    __esModule: true,
+    default: {
+      spareparts: {
+        delete: jest.fn(),
+        findUnique: jest.fn(),
+      },
+    },
+  };
+});
+
+describe("SparepartRepository - DELETE", () => {
+  let sparepartRepository: SparepartRepository;
+  let mockPrisma: jest.Mocked<PrismaClient>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPrisma = prisma as unknown as jest.Mocked<PrismaClient>;
+    sparepartRepository = new SparepartRepository();
+  });
+
+  describe("deleteSparepart", () => {
+    it("should delete a sparepart successfully", async () => {
+      const mockSparepart: SparepartsDTO = {
+        id: "1",
+        partsName: "Test Part",
+        purchaseDate: new Date("2023-01-01"),
+        price: 100,
+        toolLocation: "Warehouse A",
+        toolDate: "2023-01-05", // toolDate as string
+        createdBy: 1,
+        createdOn: new Date("2023-01-01"),
+        modifiedOn: new Date("2023-01-01"),
+      };
+
+      (mockPrisma.spareparts.delete as jest.Mock).mockResolvedValue(
+        mockSparepart,
+      );
+
+      const result = await sparepartRepository.deleteSparepart("1");
+
+      expect(mockPrisma.spareparts.delete).toHaveBeenCalledWith({
+        where: { id: "1" },
+      });
+      expect(result).toEqual(mockSparepart);
+    });
+
+    it("should handle errors when deleting a non-existent sparepart", async () => {
+      const errorMessage = "Record to delete does not exist";
+      (mockPrisma.spareparts.delete as jest.Mock).mockRejectedValue(
+        new Error(errorMessage),
+      );
+
+      await expect(sparepartRepository.deleteSparepart("999")).rejects.toThrow(
+        errorMessage,
+      );
+      expect(mockPrisma.spareparts.delete).toHaveBeenCalledWith({
+        where: { id: "999" },
+      });
+    });
+
+    it("should handle database errors during deletion", async () => {
+      const errorMessage = "Database connection error";
+      (mockPrisma.spareparts.delete as jest.Mock).mockRejectedValue(
+        new Error(errorMessage),
+      );
+
+      await expect(sparepartRepository.deleteSparepart("1")).rejects.toThrow(
+        errorMessage,
+      );
+      expect(mockPrisma.spareparts.delete).toHaveBeenCalledWith({
+        where: { id: "1" },
+      });
+    });
+
+    it("should return the deleted sparepart data", async () => {
+      const deletedSparepart: SparepartsDTO = {
+        id: "1",
+        partsName: "Test Part",
+        purchaseDate: new Date("2023-01-01"),
+        price: 100,
+        toolLocation: "Warehouse A",
+        toolDate: "2023-01-05", // toolDate as string
+        createdBy: 1,
+        createdOn: new Date("2023-01-01"),
+        modifiedOn: new Date("2023-01-01"),
+        deletedOn: new Date(),
+      };
+
+      (mockPrisma.spareparts.delete as jest.Mock).mockResolvedValue(
+        deletedSparepart,
+      );
+
+      const result = await sparepartRepository.deleteSparepart("1");
+
+      expect(mockPrisma.spareparts.delete).toHaveBeenCalledWith({
+        where: { id: "1" },
+      });
+      expect(result).toEqual(deletedSparepart);
+      expect(result!.deletedOn).toBeDefined();
+    });
+  });
+});

--- a/__tests__/unit/repository/sparepart/update-sparepart.repository-unit.test.tsx
+++ b/__tests__/unit/repository/sparepart/update-sparepart.repository-unit.test.tsx
@@ -1,0 +1,180 @@
+import { PrismaClient } from "@prisma/client";
+import SparepartRepository from "../../../../src/repository/sparepart.repository";
+import { SparepartsDTO } from "../../../../src/dto/sparepart.dto";
+import prisma from "../../../../src/configs/db.config";
+
+// Mock the Prisma client
+jest.mock("../../../../src/configs/db.config", () => {
+  return {
+    __esModule: true,
+    default: {
+      spareparts: {
+        update: jest.fn(),
+        findUnique: jest.fn(),
+      },
+    },
+  };
+});
+
+describe("SparepartRepository - UPDATE", () => {
+  let sparepartRepository: SparepartRepository;
+  let mockPrisma: jest.Mocked<PrismaClient>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPrisma = prisma as unknown as jest.Mocked<PrismaClient>;
+    sparepartRepository = new SparepartRepository();
+  });
+
+  describe("getSparepartById", () => {
+    it("should get a sparepart by id", async () => {
+      const mockSparepart: SparepartsDTO = {
+        id: "1",
+        partsName: "Test Part",
+        purchaseDate: new Date("2023-01-01"),
+        price: 100,
+        toolLocation: "Warehouse A",
+        toolDate: "2023-01-05", // toolDate as string
+        createdBy: 1,
+        createdOn: new Date("2023-01-01"),
+        modifiedOn: new Date("2023-01-01"),
+      };
+
+      (mockPrisma.spareparts.findUnique as jest.Mock).mockResolvedValue(
+        mockSparepart,
+      );
+
+      const result = await sparepartRepository.getSparepartById("1");
+
+      expect(mockPrisma.spareparts.findUnique).toHaveBeenCalledWith({
+        where: { id: "1" },
+      });
+      expect(result).toEqual(mockSparepart);
+    });
+
+    it("should return null if sparepart not found", async () => {
+      (mockPrisma.spareparts.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const result = await sparepartRepository.getSparepartById("999");
+
+      expect(mockPrisma.spareparts.findUnique).toHaveBeenCalledWith({
+        where: { id: "999" },
+      });
+      expect(result).toBeNull();
+    });
+
+    it("should handle errors when getting a sparepart", async () => {
+      const errorMessage = "Database error";
+      (mockPrisma.spareparts.findUnique as jest.Mock).mockRejectedValue(
+        new Error(errorMessage),
+      );
+
+      await expect(sparepartRepository.getSparepartById("1")).rejects.toThrow(
+        errorMessage,
+      );
+      expect(mockPrisma.spareparts.findUnique).toHaveBeenCalledWith({
+        where: { id: "1" },
+      });
+    });
+  });
+
+  describe("updateSparepart", () => {
+    it("should update a sparepart successfully", async () => {
+      const mockSparepart: SparepartsDTO = {
+        id: "1",
+        partsName: "Test Part",
+        purchaseDate: new Date("2023-01-01"),
+        price: 100,
+        toolLocation: "Warehouse A",
+        toolDate: "2023-01-05", // toolDate as string
+        createdBy: 1,
+        createdOn: new Date("2023-01-01"),
+        modifiedOn: new Date("2023-01-01"),
+      };
+
+      const updateData: Partial<SparepartsDTO> = {
+        partsName: "Updated Part",
+        price: 150,
+        toolDate: "2023-02-05", // toolDate as string
+        modifiedBy: 2,
+        modifiedOn: new Date("2023-02-01"),
+      };
+
+      const updatedSparepart = {
+        ...mockSparepart,
+        ...updateData,
+      };
+
+      (mockPrisma.spareparts.update as jest.Mock).mockResolvedValue(
+        updatedSparepart,
+      );
+
+      const result = await sparepartRepository.updateSparepart("1", updateData);
+
+      expect(mockPrisma.spareparts.update).toHaveBeenCalledWith({
+        where: { id: "1" },
+        data: updateData,
+      });
+      expect(result).toEqual(updatedSparepart);
+    });
+
+    it("should handle errors when updating a sparepart", async () => {
+      const updateData: Partial<SparepartsDTO> = {
+        partsName: "Updated Part",
+        price: 150,
+        toolDate: "2023-02-05", // toolDate as string
+      };
+
+      const errorMessage = "Record to update not found";
+      (mockPrisma.spareparts.update as jest.Mock).mockRejectedValue(
+        new Error(errorMessage),
+      );
+
+      await expect(
+        sparepartRepository.updateSparepart("999", updateData),
+      ).rejects.toThrow(errorMessage);
+      expect(mockPrisma.spareparts.update).toHaveBeenCalledWith({
+        where: { id: "999" },
+        data: updateData,
+      });
+    });
+
+    it("should update only the provided fields", async () => {
+      const mockSparepart: SparepartsDTO = {
+        id: "1",
+        partsName: "Test Part",
+        purchaseDate: new Date("2023-01-01"),
+        price: 100,
+        toolLocation: "Warehouse A",
+        toolDate: "2023-01-05", // toolDate as string
+        createdBy: 1,
+        createdOn: new Date("2023-01-01"),
+        modifiedOn: new Date("2023-01-01"),
+      };
+
+      // Only update partsName
+      const updateData: Partial<SparepartsDTO> = {
+        partsName: "Updated Part Name Only",
+      };
+
+      const updatedSparepart = {
+        ...mockSparepart,
+        partsName: "Updated Part Name Only",
+      };
+
+      (mockPrisma.spareparts.update as jest.Mock).mockResolvedValue(
+        updatedSparepart,
+      );
+
+      const result = await sparepartRepository.updateSparepart("1", updateData);
+
+      expect(mockPrisma.spareparts.update).toHaveBeenCalledWith({
+        where: { id: "1" },
+        data: updateData,
+      });
+      expect(result).toEqual(updatedSparepart);
+      expect(result!.partsName).toBe("Updated Part Name Only");
+      expect(result!.price).toBe(mockSparepart.price); // Unchanged
+    });
+  });
+});

--- a/__tests__/unit/services/sparepart/add-sparepart.service.unit.test.ts
+++ b/__tests__/unit/services/sparepart/add-sparepart.service.unit.test.ts
@@ -1,0 +1,89 @@
+import SparepartService from "../../../../src/services/sparepart.service";
+import SparepartRepository from "../../../../src/repository/sparepart.repository";
+import { SparepartsDTO } from "../../../../src/dto/sparepart.dto";
+import { v4 as uuidv4 } from "uuid";
+
+jest.mock("../../../../src/repository/sparepart.repository");
+jest.mock("uuid");
+
+describe("SparepartService - ADD", () => {
+  let sparepartService: SparepartService;
+  let mockSparepartRepository: jest.Mocked<SparepartRepository>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSparepartRepository =
+      new SparepartRepository() as jest.Mocked<SparepartRepository>;
+    sparepartService = new SparepartService();
+    (sparepartService as any).sparepartRepository = mockSparepartRepository;
+    (uuidv4 as jest.Mock).mockReturnValue("mock-uuid");
+  });
+
+  it("should add a new sparepart successfully", async () => {
+    const mockSparepartData: Partial<SparepartsDTO> = {
+      partsName: "Test Part",
+      purchaseDate: new Date(),
+      price: 100,
+      toolLocation: "Warehouse A",
+      toolDate: new Date().toISOString(),
+      createdBy: 1,
+    };
+
+    const expectedCreateData: SparepartsDTO = {
+      id: "mock-uuid",
+      partsName: mockSparepartData.partsName!,
+      purchaseDate: mockSparepartData.purchaseDate,
+      price: mockSparepartData.price,
+      toolLocation: mockSparepartData.toolLocation,
+      toolDate: mockSparepartData.toolDate,
+      createdBy: mockSparepartData.createdBy!,
+      createdOn: expect.any(Date),
+      modifiedOn: expect.any(Date),
+    };
+
+    mockSparepartRepository.createSparepart.mockResolvedValue(
+      expectedCreateData,
+    );
+
+    const result = await sparepartService.addSparepart(
+      mockSparepartData as SparepartsDTO,
+    );
+
+    expect(uuidv4).toHaveBeenCalled();
+    expect(mockSparepartRepository.createSparepart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "mock-uuid",
+        partsName: mockSparepartData.partsName,
+        purchaseDate: mockSparepartData.purchaseDate,
+        price: mockSparepartData.price,
+        toolLocation: mockSparepartData.toolLocation,
+        toolDate: mockSparepartData.toolDate,
+        createdBy: mockSparepartData.createdBy,
+        createdOn: expect.any(Date),
+        modifiedOn: expect.any(Date),
+      }),
+    );
+    expect(result).toEqual(expectedCreateData);
+  });
+
+  it("should handle errors when creating a sparepart", async () => {
+    const mockSparepartData: Partial<SparepartsDTO> = {
+      partsName: "Test Part",
+      purchaseDate: new Date(),
+      price: 100,
+      toolLocation: "Warehouse A",
+      toolDate: new Date().toISOString(),
+      createdBy: 1,
+    };
+
+    const errorMessage = "Database error";
+    mockSparepartRepository.createSparepart.mockRejectedValue(
+      new Error(errorMessage),
+    );
+
+    await expect(
+      sparepartService.addSparepart(mockSparepartData as SparepartsDTO),
+    ).rejects.toThrow(errorMessage);
+    expect(mockSparepartRepository.createSparepart).toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/services/sparepart/delete-sparepart.service.unit.test.ts
+++ b/__tests__/unit/services/sparepart/delete-sparepart.service.unit.test.ts
@@ -1,0 +1,87 @@
+import SparepartService from "../../../../src/services/sparepart.service";
+import SparepartRepository from "../../../../src/repository/sparepart.repository";
+import { SparepartsDTO } from "../../../../src/dto/sparepart.dto";
+
+jest.mock("../../../../src/repository/sparepart.repository");
+
+describe("SparepartService - DELETE", () => {
+  let sparepartService: SparepartService;
+  let mockSparepartRepository: jest.Mocked<SparepartRepository>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSparepartRepository =
+      new SparepartRepository() as jest.Mocked<SparepartRepository>;
+    sparepartService = new SparepartService();
+    (sparepartService as any).sparepartRepository = mockSparepartRepository;
+  });
+
+  describe("deleteSparepart", () => {
+    it("should delete a sparepart by id", async () => {
+      const mockSparepart: SparepartsDTO = {
+        id: "1",
+        partsName: "Test Part",
+        purchaseDate: new Date("2023-01-01"),
+        price: 100,
+        toolLocation: "Warehouse A",
+        toolDate: new Date("2023-01-05").toISOString(),
+        createdBy: 1,
+        createdOn: new Date("2023-01-01"),
+        modifiedOn: new Date("2023-01-01"),
+        deletedOn: new Date(),
+      };
+
+      mockSparepartRepository.getSparepartById.mockResolvedValue(mockSparepart);
+      mockSparepartRepository.deleteSparepart.mockResolvedValue(mockSparepart);
+
+      const result = await sparepartService.deleteSparepart("1");
+
+      expect(mockSparepartRepository.getSparepartById).toHaveBeenCalledWith(
+        "1",
+      );
+      expect(mockSparepartRepository.deleteSparepart).toHaveBeenCalledWith("1");
+      expect(result).toEqual(mockSparepart);
+    });
+
+    it("should return null if sparepart not found", async () => {
+      mockSparepartRepository.getSparepartById.mockResolvedValue(null);
+
+      const result = await sparepartService.deleteSparepart("999");
+
+      expect(mockSparepartRepository.getSparepartById).toHaveBeenCalledWith(
+        "999",
+      );
+      expect(mockSparepartRepository.deleteSparepart).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it("should handle errors", async () => {
+      const mockSparepart: SparepartsDTO = {
+        id: "1",
+        partsName: "Test Part",
+        purchaseDate: new Date("2023-01-01"),
+        price: 100,
+        toolLocation: "Warehouse A",
+        toolDate: new Date("2023-01-05").toISOString(),
+        createdBy: 1,
+        createdOn: new Date("2023-01-01"),
+        modifiedOn: new Date("2023-01-01"),
+      };
+
+      mockSparepartRepository.getSparepartById.mockResolvedValue(mockSparepart);
+
+      const errorMessage = "Database error";
+      mockSparepartRepository.deleteSparepart.mockRejectedValue(
+        new Error(errorMessage),
+      );
+
+      await expect(sparepartService.deleteSparepart("1")).rejects.toThrow(
+        errorMessage,
+      );
+      expect(mockSparepartRepository.getSparepartById).toHaveBeenCalledWith(
+        "1",
+      );
+      expect(mockSparepartRepository.deleteSparepart).toHaveBeenCalledWith("1");
+    });
+  });
+});

--- a/__tests__/unit/services/sparepart/update-sparepart.service.unit.test.ts
+++ b/__tests__/unit/services/sparepart/update-sparepart.service.unit.test.ts
@@ -1,0 +1,233 @@
+import SparepartService from "../../../../src/services/sparepart.service";
+import SparepartRepository from "../../../../src/repository/sparepart.repository";
+import { SparepartsDTO } from "../../../../src/dto/sparepart.dto";
+
+jest.mock("../../../../src/repository/sparepart.repository");
+
+describe("SparepartService - UPDATE", () => {
+  let sparepartService: SparepartService;
+  let mockSparepartRepository: jest.Mocked<SparepartRepository>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSparepartRepository =
+      new SparepartRepository() as jest.Mocked<SparepartRepository>;
+    sparepartService = new SparepartService();
+    (sparepartService as any).sparepartRepository = mockSparepartRepository;
+  });
+
+  describe("updateSparepart", () => {
+    it("should update a sparepart successfully", async () => {
+      const mockSparepart: SparepartsDTO = {
+        id: "1",
+        partsName: "Original Part",
+        purchaseDate: new Date("2023-01-01"),
+        price: 100,
+        toolLocation: "Warehouse A",
+        toolDate: new Date("2023-01-05").toISOString(),
+        createdBy: 1,
+        createdOn: new Date("2023-01-01"),
+        modifiedOn: new Date("2023-01-01"),
+      };
+
+      const updatedData: Partial<SparepartsDTO> = {
+        partsName: "Updated Part",
+        price: 150,
+        modifiedBy: 2,
+      };
+
+      const updatedSparepart: SparepartsDTO = {
+        ...mockSparepart,
+        partsName: "Updated Part",
+        price: 150,
+        modifiedBy: 2,
+        modifiedOn: expect.any(Date),
+      };
+
+      mockSparepartRepository.getSparepartById.mockResolvedValue(mockSparepart);
+      mockSparepartRepository.updateSparepart.mockResolvedValue(
+        updatedSparepart,
+      );
+
+      const result = await sparepartService.updateSparepart("1", updatedData);
+
+      expect(mockSparepartRepository.getSparepartById).toHaveBeenCalledWith(
+        "1",
+      );
+      expect(mockSparepartRepository.updateSparepart).toHaveBeenCalledWith(
+        "1",
+        {
+          partsName: updatedData.partsName,
+          purchaseDate: updatedData.purchaseDate,
+          price: updatedData.price,
+          toolLocation: updatedData.toolLocation,
+          toolDate: updatedData.toolDate,
+          modifiedBy: updatedData.modifiedBy,
+          modifiedOn: expect.any(Date),
+        },
+      );
+      expect(result).toEqual(updatedSparepart);
+    });
+
+    it("should return null if sparepart not found", async () => {
+      mockSparepartRepository.getSparepartById.mockResolvedValue(null);
+
+      const result = await sparepartService.updateSparepart("999", {
+        partsName: "Updated Part",
+        modifiedBy: 2,
+      });
+
+      expect(mockSparepartRepository.getSparepartById).toHaveBeenCalledWith(
+        "999",
+      );
+      expect(mockSparepartRepository.updateSparepart).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it("should return null if data is invalid", async () => {
+      const mockSparepart: SparepartsDTO = {
+        id: "1",
+        partsName: "Original Part",
+        purchaseDate: new Date("2023-01-01"),
+        price: 100,
+        toolLocation: "Warehouse A",
+        toolDate: new Date("2023-01-05").toISOString(),
+        createdBy: 1,
+        createdOn: new Date("2023-01-01"),
+        modifiedOn: new Date("2023-01-01"),
+      };
+
+      // Invalid data: missing modifiedBy
+      const invalidData: Partial<SparepartsDTO> = {
+        partsName: "Updated Part",
+        price: 150,
+      };
+
+      mockSparepartRepository.getSparepartById.mockResolvedValue(mockSparepart);
+
+      const result = await sparepartService.updateSparepart("1", invalidData);
+
+      expect(mockSparepartRepository.getSparepartById).toHaveBeenCalledWith(
+        "1",
+      );
+      expect(mockSparepartRepository.updateSparepart).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it("should return null if price is negative", async () => {
+      const mockSparepart: SparepartsDTO = {
+        id: "1",
+        partsName: "Original Part",
+        purchaseDate: new Date("2023-01-01"),
+        price: 100,
+        toolLocation: "Warehouse A",
+        toolDate: new Date("2023-01-05").toISOString(),
+        createdBy: 1,
+        createdOn: new Date("2023-01-01"),
+        modifiedOn: new Date("2023-01-01"),
+      };
+
+      // Invalid data: negative price
+      const invalidData: Partial<SparepartsDTO> = {
+        partsName: "Updated Part",
+        price: -50,
+        modifiedBy: 2,
+      };
+
+      mockSparepartRepository.getSparepartById.mockResolvedValue(mockSparepart);
+
+      const result = await sparepartService.updateSparepart("1", invalidData);
+
+      expect(mockSparepartRepository.getSparepartById).toHaveBeenCalledWith(
+        "1",
+      );
+      expect(mockSparepartRepository.updateSparepart).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it("should return null if partsName is empty", async () => {
+      const mockSparepart: SparepartsDTO = {
+        id: "1",
+        partsName: "Original Part",
+        purchaseDate: new Date("2023-01-01"),
+        price: 100,
+        toolLocation: "Warehouse A",
+        toolDate: new Date("2023-01-05").toISOString(),
+        createdBy: 1,
+        createdOn: new Date("2023-01-01"),
+        modifiedOn: new Date("2023-01-01"),
+      };
+
+      // Invalid data: empty partsName
+      const invalidData: Partial<SparepartsDTO> = {
+        partsName: "   ",
+        modifiedBy: 2,
+      };
+
+      mockSparepartRepository.getSparepartById.mockResolvedValue(mockSparepart);
+
+      const result = await sparepartService.updateSparepart("1", invalidData);
+
+      expect(mockSparepartRepository.getSparepartById).toHaveBeenCalledWith(
+        "1",
+      );
+      expect(mockSparepartRepository.updateSparepart).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("validateSparepartData", () => {
+    it("should return true for valid data", () => {
+      const validData: Partial<SparepartsDTO> = {
+        partsName: "Valid Part",
+        price: 100,
+        modifiedBy: 1,
+      };
+
+      const result = (sparepartService as any).validateSparepartData(validData);
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false if modifiedBy is undefined", () => {
+      const invalidData: Partial<SparepartsDTO> = {
+        partsName: "Valid Part",
+        price: 100,
+      };
+
+      const result = (sparepartService as any).validateSparepartData(
+        invalidData,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it("should return false if partsName is empty", () => {
+      const invalidData: Partial<SparepartsDTO> = {
+        partsName: "  ",
+        price: 100,
+        modifiedBy: 1,
+      };
+
+      const result = (sparepartService as any).validateSparepartData(
+        invalidData,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it("should return false if price is negative", () => {
+      const invalidData: Partial<SparepartsDTO> = {
+        partsName: "Valid Part",
+        price: -10,
+        modifiedBy: 1,
+      };
+
+      const result = (sparepartService as any).validateSparepartData(
+        invalidData,
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/controllers/sparepart.controller.ts
+++ b/src/controllers/sparepart.controller.ts
@@ -27,6 +27,27 @@ class SparepartController {
     }
   };
 
+  public updateSparepart = async (
+    req: Request,
+    res: Response,
+  ): Promise<void> => {
+    try {
+      const sparepart = await this.sparepartService.updateSparepart(
+        req.params.id,
+        req.body,
+      );
+      if (!sparepart) {
+        res
+          .status(404)
+          .json({ message: "Sparepart not found or invalid data" });
+        return;
+      }
+      res.status(200).json(sparepart);
+    } catch (error) {
+      res.status(500).json({ message: (error as Error).message });
+    }
+  };
+
   public deleteSparepart = async (
     req: Request,
     res: Response,

--- a/src/controllers/sparepart.controller.ts
+++ b/src/controllers/sparepart.controller.ts
@@ -1,0 +1,49 @@
+import { Request, Response } from "express";
+import SparepartService from "../services/sparepart.service";
+import { SparepartsDTO } from "../dto/sparepart.dto";
+import { validationResult } from "express-validator";
+
+class SparepartController {
+  private readonly sparepartService: SparepartService;
+
+  constructor() {
+    this.sparepartService = new SparepartService();
+  }
+
+  public addSparepart = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        res.status(400).json({ errors: errors.array() });
+        return;
+      }
+
+      const sparepartData: SparepartsDTO = req.body;
+      const newSparepart =
+        await this.sparepartService.addSparepart(sparepartData);
+      res.status(201).json(newSparepart);
+    } catch (error) {
+      res.status(500).json({ error: (error as Error).message });
+    }
+  };
+
+  public deleteSparepart = async (
+    req: Request,
+    res: Response,
+  ): Promise<void> => {
+    try {
+      const sparepart = await this.sparepartService.deleteSparepart(
+        req.params.id,
+      );
+      if (!sparepart) {
+        res.status(404).json({ message: "Sparepart not found" });
+        return;
+      }
+      res.status(200).json({ message: "Sparepart deleted successfully" });
+    } catch (error) {
+      res.status(500).json({ message: (error as Error).message });
+    }
+  };
+}
+
+export default SparepartController;

--- a/src/dto/sparepart.dto.ts
+++ b/src/dto/sparepart.dto.ts
@@ -1,0 +1,14 @@
+export interface SparepartsDTO {
+  id: string;
+  partsName: string;
+  purchaseDate?: Date | null;
+  price?: number | null;
+  toolLocation?: string | null;
+  toolDate?: string | null;
+  createdBy: number;
+  createdOn?: Date | null;
+  modifiedBy?: number | null;
+  modifiedOn: Date;
+  deletedBy?: number | null;
+  deletedOn?: Date | null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,11 +8,12 @@ import cors from "cors";
 import express from "express";
 import userRoutes from "./routes/user.route";
 import authRoutes from "./routes/auth.route";
-import 'dotenv/config';
+import sparepartRoutes from "./routes/sparepart.route";
+import "dotenv/config";
 
 const app = express();
 
-app.disable('x-powered-by');
+app.disable("x-powered-by");
 
 const whitelist: string[] = [];
 
@@ -42,13 +43,14 @@ app.get("/", (req, res) => {
   res.send("PPL C-5 DEPLOYED!!!");
 });
 
-app.use('/auth', authRoutes);
-app.use('/user', userRoutes);
+app.use("/auth", authRoutes);
+app.use("/user", userRoutes);
+app.use("/sparepart", sparepartRoutes);
 
 const PORT = process.env.PORT || 8000;
 const server = app.listen(PORT, () => {
   console.log(`Server listening on port: ${PORT}`);
-  console.log(`CORS enabled for origins: ${whitelist.join(', ')}`);
+  console.log(`CORS enabled for origins: ${whitelist.join(", ")}`);
 });
 
 export default server;

--- a/src/repository/sparepart.repository.ts
+++ b/src/repository/sparepart.repository.ts
@@ -24,6 +24,16 @@ class SparepartRepository {
     });
   }
 
+  public async updateSparepart(
+    id: string,
+    data: Partial<SparepartsDTO>,
+  ): Promise<SparepartsDTO | null> {
+    return await this.prisma.spareparts.update({
+      where: { id },
+      data,
+    });
+  }
+
   public async deleteSparepart(id: string): Promise<SparepartsDTO | null> {
     return await this.prisma.spareparts.delete({
       where: { id },

--- a/src/repository/sparepart.repository.ts
+++ b/src/repository/sparepart.repository.ts
@@ -1,0 +1,34 @@
+import { PrismaClient } from "@prisma/client";
+import { SparepartsDTO } from "../dto/sparepart.dto";
+
+import prisma from "../configs/db.config";
+
+class SparepartRepository {
+  private readonly prisma: PrismaClient;
+
+  constructor() {
+    this.prisma = prisma;
+  }
+
+  public async createSparepart(data: any): Promise<SparepartsDTO> {
+    const newSparepart = await this.prisma.spareparts.create({
+      data,
+    });
+
+    return newSparepart;
+  }
+
+  public async getSparepartById(id: string): Promise<SparepartsDTO | null> {
+    return await this.prisma.spareparts.findUnique({
+      where: { id },
+    });
+  }
+
+  public async deleteSparepart(id: string): Promise<SparepartsDTO | null> {
+    return await this.prisma.spareparts.delete({
+      where: { id },
+    });
+  }
+}
+
+export default SparepartRepository;

--- a/src/routes/sparepart.route.ts
+++ b/src/routes/sparepart.route.ts
@@ -6,8 +6,13 @@ import { addSparepartValidation } from "../validations/addsparepart.validation";
 const router = Router();
 const sparepartController = new SparepartController();
 
-router.post("/", addSparepartValidation, sparepartController.addSparepart);
-router.put("/:id", sparepartController.updateSparepart);
-router.delete("/:id", sparepartController.deleteSparepart);
+router.post(
+  "/",
+  verifyToken,
+  addSparepartValidation,
+  sparepartController.addSparepart,
+);
+router.put("/:id", verifyToken, sparepartController.updateSparepart);
+router.delete("/:id", verifyToken, sparepartController.deleteSparepart);
 
 export default router;

--- a/src/routes/sparepart.route.ts
+++ b/src/routes/sparepart.route.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import SparepartController from "../controllers/sparepart.controller";
+import verifyToken from "../middleware/verifyToken";
+import { addSparepartValidation } from "../validations/addsparepart.validation";
+
+const router = Router();
+const sparepartController = new SparepartController();
+
+router.post("/", addSparepartValidation, sparepartController.addSparepart);
+router.delete("/:id", sparepartController.deleteSparepart);
+
+export default router;

--- a/src/routes/sparepart.route.ts
+++ b/src/routes/sparepart.route.ts
@@ -7,6 +7,7 @@ const router = Router();
 const sparepartController = new SparepartController();
 
 router.post("/", addSparepartValidation, sparepartController.addSparepart);
+router.put("/:id", sparepartController.updateSparepart);
 router.delete("/:id", sparepartController.deleteSparepart);
 
 export default router;

--- a/src/services/interface/sparepart.service.interface.ts
+++ b/src/services/interface/sparepart.service.interface.ts
@@ -1,0 +1,6 @@
+import { SparepartsDTO } from "../../dto/sparepart.dto";
+
+export interface ISparepartService {
+  addSparepart(userData: SparepartsDTO): Promise<SparepartsDTO>;
+  deleteSparepart(id: string): Promise<SparepartsDTO | null>;
+}

--- a/src/services/interface/sparepart.service.interface.ts
+++ b/src/services/interface/sparepart.service.interface.ts
@@ -2,5 +2,9 @@ import { SparepartsDTO } from "../../dto/sparepart.dto";
 
 export interface ISparepartService {
   addSparepart(userData: SparepartsDTO): Promise<SparepartsDTO>;
+  updateSparepart(
+    id: string,
+    data: Partial<SparepartsDTO>,
+  ): Promise<SparepartsDTO | null>;
   deleteSparepart(id: string): Promise<SparepartsDTO | null>;
 }

--- a/src/services/sparepart.service.ts
+++ b/src/services/sparepart.service.ts
@@ -26,6 +26,35 @@ class SparepartService implements ISparepartService {
     return await this.sparepartRepository.createSparepart(createData);
   }
 
+  private validateSparepartData(data: Partial<SparepartsDTO>): boolean {
+    if (!data.modifiedBy) return false;
+    if (data.partsName && data.partsName.trim().length === 0) return false;
+    if (data.price && data.price < 0) return false;
+    return true;
+  }
+
+  public async updateSparepart(
+    id: string,
+    data: Partial<SparepartsDTO>,
+  ): Promise<SparepartsDTO | null> {
+    const sparepart = await this.sparepartRepository.getSparepartById(id);
+    if (!sparepart || !this.validateSparepartData(data)) {
+      return null;
+    }
+
+    const updatedData: Partial<SparepartsDTO> = {
+      partsName: data.partsName,
+      purchaseDate: data.purchaseDate,
+      price: data.price,
+      toolLocation: data.toolLocation,
+      toolDate: data.toolDate,
+      modifiedBy: data.modifiedBy,
+      modifiedOn: new Date(),
+    };
+
+    return await this.sparepartRepository.updateSparepart(id, updatedData);
+  }
+
   public async deleteSparepart(id: string): Promise<SparepartsDTO | null> {
     const sparepart = await this.sparepartRepository.getSparepartById(id);
     if (!sparepart) {

--- a/src/services/sparepart.service.ts
+++ b/src/services/sparepart.service.ts
@@ -1,0 +1,43 @@
+import { SparepartsDTO } from "../dto/sparepart.dto";
+import { ISparepartService } from "./interface/sparepart.service.interface";
+import SparepartRepository from "../repository/sparepart.repository";
+import { v4 as uuidv4 } from "uuid";
+
+class SparepartService implements ISparepartService {
+  private readonly sparepartRepository: SparepartRepository;
+
+  constructor() {
+    this.sparepartRepository = new SparepartRepository();
+  }
+
+  public async addSparepart(data: SparepartsDTO): Promise<SparepartsDTO> {
+    const createData: SparepartsDTO = {
+      id: uuidv4(),
+      partsName: data.partsName,
+      purchaseDate: data.purchaseDate,
+      price: data.price,
+      toolLocation: data.toolLocation,
+      toolDate: data.toolDate,
+      createdBy: data.createdBy,
+      createdOn: new Date(),
+      modifiedOn: new Date(),
+    };
+
+    return await this.sparepartRepository.createSparepart(createData);
+  }
+
+  public async deleteSparepart(id: string): Promise<SparepartsDTO | null> {
+    const sparepart = await this.sparepartRepository.getSparepartById(id);
+    if (!sparepart) {
+      return null;
+    }
+
+    const deletedData: Partial<SparepartsDTO> = {
+      deletedOn: new Date(),
+    };
+
+    return await this.sparepartRepository.deleteSparepart(id);
+  }
+}
+
+export default SparepartService;

--- a/src/validations/addsparepart.validation.ts
+++ b/src/validations/addsparepart.validation.ts
@@ -1,0 +1,59 @@
+import { body } from "express-validator";
+
+export const addSparepartValidation = [
+  body("partsName")
+    .isString()
+    .trim()
+    .notEmpty()
+    .withMessage("Sparepart name is required"),
+
+  body("purchaseDate")
+    .optional()
+    .isISO8601()
+    .toDate()
+    .withMessage("Purchase date must be a valid date"),
+
+  body("price").optional().isNumeric().withMessage("Price must be a number"),
+
+  body("toolLocation")
+    .optional()
+    .isString()
+    .trim()
+    .withMessage("Tool location must be a string"),
+
+  body("toolDate")
+    .optional()
+    .isString()
+    .toDate()
+    .withMessage("Tool date must be a valid date"),
+
+  body("createdBy").isInt().withMessage("CreatedBy must be an integer"),
+
+  body("createdOn")
+    .optional()
+    .isISO8601()
+    .toDate()
+    .withMessage("CreatedOn must be a valid date"),
+
+  body("modifiedBy")
+    .optional()
+    .isInt()
+    .withMessage("ModifiedBy must be an integer"),
+
+  body("modifiedOn")
+    .optional()
+    .isISO8601()
+    .toDate()
+    .withMessage("ModifiedOn must be a valid date"),
+
+  body("deletedBy")
+    .optional()
+    .isInt()
+    .withMessage("DeletedBy must be an integer"),
+
+  body("deletedOn")
+    .optional()
+    .isISO8601()
+    .toDate()
+    .withMessage("DeletedOn must be a valid date"),
+];


### PR DESCRIPTION
# Update Sparepart
Closes #13 #55 #57 #59 #61

## Endpoint
- **Update Sparepart**: PUT {{base_url}}/sparepart/:id

## Summary
- **Update Sparepart** : Created API to enable admin to update sparepart
- All tests already satisfied with 100% coverage

## Next Steps  
- Implement role based authorization for spareparts API