### PR TITLE
[FEAT] Monthly Requests Report

### DIFF
--- a/__tests__/unit/controllers/report/get-monthly-requests-report.controller.unit.test.ts
+++ b/__tests__/unit/controllers/report/get-monthly-requests-report.controller.unit.test.ts
@@ -1,0 +1,203 @@
+import { Request, Response, NextFunction } from "express";
+import ReportController from "../../../../src/controllers/report.controller";
+import ReportService from "../../../../src/services/report.service";
+
+// Mock the ReportService
+jest.mock("../../../../src/services/report.service");
+
+describe("ReportController - getMonthlyRequestCounts", () => {
+  let controller: ReportController;
+  let mockReq: Partial<Request>;
+  let mockRes: Partial<Response>;
+  let mockNext: NextFunction;
+  let mockReportService: jest.Mocked<ReportService>;
+
+  beforeEach(() => {
+    // Setup request, response, and next function mocks
+    mockReq = {};
+    mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    mockNext = jest.fn();
+
+    // Setup ReportService mock
+    mockReportService = new ReportService() as jest.Mocked<ReportService>;
+
+    // Create controller with mocked service
+    controller = new ReportController();
+    // Replace the service instance with our mock
+    (controller as any).reportService = mockReportService;
+  });
+
+  // POSITIVE CASES
+  describe("Positive cases", () => {
+    it("should return monthly request counts when service call succeeds with multiple months", async () => {
+      // Arrange
+      const mockData = [
+        { month: "2025-05", MAINTENANCE: 10, CALIBRATION: 5 },
+        { month: "2025-04", MAINTENANCE: 8, CALIBRATION: 3 },
+      ];
+
+      mockReportService.getMonthlyRequestCounts = jest.fn().mockResolvedValue({
+        success: true,
+        data: mockData,
+      });
+
+      // Act
+      await controller.getMonthlyRequestCounts(
+        mockReq as Request,
+        mockRes as Response,
+        mockNext,
+      );
+
+      // Assert
+      expect(mockReportService.getMonthlyRequestCounts).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        success: true,
+        message: "Monthly request counts retrieved successfully",
+        data: mockData,
+      });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it("should handle service returning a large dataset (12 months)", async () => {
+      // Arrange
+      const mockData = Array.from({ length: 12 }, (_, i) => ({
+        month: `2025-${String(i + 1).padStart(2, "0")}`,
+        MAINTENANCE: Math.floor(Math.random() * 20),
+        CALIBRATION: Math.floor(Math.random() * 10),
+      }));
+
+      mockReportService.getMonthlyRequestCounts = jest.fn().mockResolvedValue({
+        success: true,
+        data: mockData,
+      });
+
+      // Act
+      await controller.getMonthlyRequestCounts(
+        mockReq as Request,
+        mockRes as Response,
+        mockNext,
+      );
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        success: true,
+        message: "Monthly request counts retrieved successfully",
+        data: mockData,
+      });
+    });
+  });
+
+  // EDGE CASES
+  describe("Edge cases", () => {
+    it("should handle empty data array from service", async () => {
+      // Arrange
+      const mockData: any[] = [];
+
+      mockReportService.getMonthlyRequestCounts = jest.fn().mockResolvedValue({
+        success: true,
+        data: mockData,
+      });
+
+      // Act
+      await controller.getMonthlyRequestCounts(
+        mockReq as Request,
+        mockRes as Response,
+        mockNext,
+      );
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        success: true,
+        message: "Monthly request counts retrieved successfully",
+        data: mockData,
+      });
+    });
+
+    it("should handle service returning data with zero counts", async () => {
+      // Arrange
+      const mockData = [
+        { month: "2025-05", MAINTENANCE: 0, CALIBRATION: 0 },
+        { month: "2025-04", MAINTENANCE: 0, CALIBRATION: 0 },
+      ];
+
+      mockReportService.getMonthlyRequestCounts = jest.fn().mockResolvedValue({
+        success: true,
+        data: mockData,
+      });
+
+      // Act
+      await controller.getMonthlyRequestCounts(
+        mockReq as Request,
+        mockRes as Response,
+        mockNext,
+      );
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        success: true,
+        message: "Monthly request counts retrieved successfully",
+        data: mockData,
+      });
+    });
+  });
+
+  // NEGATIVE CASES
+  describe("Negative cases", () => {
+    it("should call next with error when service call fails with generic error", async () => {
+      // Arrange
+      const mockError = new Error("Test error");
+      mockReportService.getMonthlyRequestCounts = jest
+        .fn()
+        .mockRejectedValue(mockError);
+
+      // Act
+      await controller.getMonthlyRequestCounts(
+        mockReq as Request,
+        mockRes as Response,
+        mockNext,
+      );
+
+      // Assert
+      expect(mockReportService.getMonthlyRequestCounts).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(mockRes.status).not.toHaveBeenCalled();
+      expect(mockRes.json).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledWith(mockError);
+    });
+
+    it("should call next with error when service throws a specific error type", async () => {
+      // Arrange
+      class DatabaseError extends Error {
+        constructor(message: string) {
+          super(message);
+          this.name = "DatabaseError";
+        }
+      }
+
+      const mockError = new DatabaseError("Database connection failed");
+      mockReportService.getMonthlyRequestCounts = jest
+        .fn()
+        .mockRejectedValue(mockError);
+
+      // Act
+      await controller.getMonthlyRequestCounts(
+        mockReq as Request,
+        mockRes as Response,
+        mockNext,
+      );
+
+      // Assert
+      expect(mockNext).toHaveBeenCalledWith(mockError);
+    });
+  });
+});

--- a/__tests__/unit/repository/report/get-monthly-requests-report.repository.unit.test.ts
+++ b/__tests__/unit/repository/report/get-monthly-requests-report.repository.unit.test.ts
@@ -1,0 +1,161 @@
+import ReportRepository from "../../../../src/repository/report.repository";
+
+// Mock the Prisma client
+jest.mock("../../../../src/configs/db.config", () => {
+  return {
+    __esModule: true,
+    default: {
+      request: {
+        findMany: jest.fn(),
+      },
+    },
+  };
+});
+
+// Import after mocking
+import prisma from "../../../../src/configs/db.config";
+
+describe("ReportRepository - getMonthlyRequestCounts", () => {
+  let repository: ReportRepository;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    repository = new ReportRepository();
+  });
+
+  // POSITIVE CASES
+  describe("Positive cases", () => {
+    it("should group requests by month and type correctly", async () => {
+      // Arrange
+      const mockRequests = [
+        { createdOn: new Date("2025-05-15"), requestType: "MAINTENANCE" },
+        { createdOn: new Date("2025-05-20"), requestType: "MAINTENANCE" },
+        { createdOn: new Date("2025-05-10"), requestType: "CALIBRATION" },
+        { createdOn: new Date("2025-04-05"), requestType: "MAINTENANCE" },
+        { createdOn: new Date("2025-04-20"), requestType: "CALIBRATION" },
+      ];
+
+      (prisma.request.findMany as jest.Mock).mockResolvedValue(mockRequests);
+
+      // Act
+      const result = await repository.getMonthlyRequestCounts();
+
+      // Assert
+      expect(prisma.request.findMany).toHaveBeenCalledWith({
+        select: {
+          createdOn: true,
+          requestType: true,
+        },
+        where: {
+          createdOn: {
+            not: null,
+          },
+        },
+      });
+
+      expect(result).toHaveLength(2);
+
+      // Check May data
+      const mayData = result.find((item) => item.month === "2025-05");
+      expect(mayData).toBeDefined();
+      expect(mayData!.MAINTENANCE).toBe(2);
+      expect(mayData!.CALIBRATION).toBe(1);
+
+      // Check April data
+      const aprilData = result.find((item) => item.month === "2025-04");
+      expect(aprilData).toBeDefined();
+      expect(aprilData!.MAINTENANCE).toBe(1);
+      expect(aprilData!.CALIBRATION).toBe(1);
+    });
+
+    it("should handle requests all from the same month", async () => {
+      // Arrange
+      const mockRequests = [
+        { createdOn: new Date("2025-05-15"), requestType: "MAINTENANCE" },
+        { createdOn: new Date("2025-05-20"), requestType: "MAINTENANCE" },
+        { createdOn: new Date("2025-05-10"), requestType: "CALIBRATION" },
+      ];
+
+      (prisma.request.findMany as jest.Mock).mockResolvedValue(mockRequests);
+
+      // Act
+      const result = await repository.getMonthlyRequestCounts();
+
+      // Assert
+      expect(result).toHaveLength(1);
+      expect(result[0].month).toBe("2025-05");
+      expect(result[0].MAINTENANCE).toBe(2);
+      expect(result[0].CALIBRATION).toBe(1);
+    });
+  });
+
+  // EDGE CASES
+  describe("Edge cases", () => {
+    it("should return empty array when there are no requests", async () => {
+      // Arrange
+      (prisma.request.findMany as jest.Mock).mockResolvedValue([]);
+
+      // Act
+      const result = await repository.getMonthlyRequestCounts();
+
+      // Assert
+      expect(result).toEqual([]);
+    });
+
+    it("should ignore requests with null createdOn", async () => {
+      // Arrange
+      const mockRequests = [
+        { createdOn: new Date("2025-05-15"), requestType: "MAINTENANCE" },
+        { createdOn: null, requestType: "MAINTENANCE" },
+        { createdOn: new Date("2025-05-10"), requestType: "CALIBRATION" },
+      ];
+
+      (prisma.request.findMany as jest.Mock).mockResolvedValue(mockRequests);
+
+      // Act
+      const result = await repository.getMonthlyRequestCounts();
+
+      // Assert
+      expect(result).toHaveLength(1);
+      expect(result[0].month).toBe("2025-05");
+      expect(result[0].MAINTENANCE).toBe(1);
+      expect(result[0].CALIBRATION).toBe(1);
+    });
+
+    it("should ignore requests with invalid requestType", async () => {
+      // Arrange
+      const mockRequests = [
+        { createdOn: new Date("2025-05-15"), requestType: "MAINTENANCE" },
+        { createdOn: new Date("2025-05-20"), requestType: "INVALID_TYPE" }, // Invalid type
+        { createdOn: new Date("2025-05-10"), requestType: "CALIBRATION" },
+      ];
+
+      (prisma.request.findMany as jest.Mock).mockResolvedValue(mockRequests);
+
+      // Act
+      const result = await repository.getMonthlyRequestCounts();
+
+      // Assert
+      expect(result).toHaveLength(1);
+      expect(result[0].month).toBe("2025-05");
+      expect(result[0].MAINTENANCE).toBe(1);
+      expect(result[0].CALIBRATION).toBe(1);
+      // The INVALID_TYPE should not appear in the results
+      expect(Object.keys(result[0]).includes("INVALID_TYPE")).toBe(false);
+    });
+  });
+
+  // NEGATIVE CASES
+  describe("Negative cases", () => {
+    it("should throw an error when Prisma query fails", async () => {
+      // Arrange
+      const mockError = new Error("Database connection error");
+      (prisma.request.findMany as jest.Mock).mockRejectedValue(mockError);
+
+      // Act & Assert
+      await expect(repository.getMonthlyRequestCounts()).rejects.toThrow(
+        "Database connection error",
+      );
+    });
+  });
+});

--- a/__tests__/unit/services/report/get-monthly-requests-report.service.unit.test.ts
+++ b/__tests__/unit/services/report/get-monthly-requests-report.service.unit.test.ts
@@ -1,0 +1,192 @@
+import ReportService from "../../../../src/services/report.service";
+import ReportRepository from "../../../../src/repository/report.repository";
+import { MonthlyDataRecord } from "../../../../src/interfaces/report.interface";
+
+// Mock dependencies
+jest.mock("../../../../src/repository/report.repository");
+jest.mock("../../../../src/utils/date.utils", () => ({
+  getJakartaTime: jest.fn(() => new Date("2025-05-15")),
+}));
+
+describe("ReportService - getMonthlyRequestCounts", () => {
+  let service: ReportService;
+  let mockRepository: jest.Mocked<ReportRepository>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRepository = new ReportRepository() as jest.Mocked<ReportRepository>;
+    service = new ReportService();
+    (service as any).reportRepository = mockRepository;
+  });
+
+  // POSITIVE CASES
+  describe("Positive cases", () => {
+    it("should return data for last 12 months with actual counts merged in", async () => {
+      // Arrange
+      const mockRawData: MonthlyDataRecord[] = [
+        { month: "2025-05", MAINTENANCE: 10, CALIBRATION: 5 },
+        { month: "2025-03", MAINTENANCE: 8, CALIBRATION: 3 },
+      ];
+
+      mockRepository.getMonthlyRequestCounts = jest
+        .fn()
+        .mockResolvedValue(mockRawData);
+
+      // Act
+      const result = await service.getMonthlyRequestCounts();
+
+      // Assert
+      expect(mockRepository.getMonthlyRequestCounts).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(true);
+      expect(result.data).toHaveLength(12); // 12 months of data
+
+      // Check that our mock data was integrated correctly
+      const mayData = result.data.find((d) => d.month === "2025-05");
+      expect(mayData).toBeDefined();
+      expect(mayData!.MAINTENANCE).toBe(10);
+      expect(mayData!.CALIBRATION).toBe(5);
+
+      const marchData = result.data.find((d) => d.month === "2025-03");
+      expect(marchData).toBeDefined();
+      expect(marchData!.MAINTENANCE).toBe(8);
+      expect(marchData!.CALIBRATION).toBe(3);
+
+      // Check that a month not in our mock data has zero counts
+      const aprilData = result.data.find((d) => d.month === "2025-04");
+      expect(aprilData).toBeDefined();
+      expect(aprilData!.MAINTENANCE).toBe(0);
+      expect(aprilData!.CALIBRATION).toBe(0);
+    });
+
+    it("should return results sorted by month in descending order", async () => {
+      // Arrange
+      mockRepository.getMonthlyRequestCounts = jest.fn().mockResolvedValue([]);
+
+      // Act
+      const result = await service.getMonthlyRequestCounts();
+
+      // Assert
+      // Check the first three months to verify descending order
+      expect(result.data[0].month).toBe("2025-05");
+      expect(result.data[1].month).toBe("2025-04");
+      expect(result.data[2].month).toBe("2025-03");
+
+      // Additional check to ensure the entire array is sorted
+      const isSorted = result.data.every(
+        (item, i, arr) =>
+          i === 0 || item.month.localeCompare(arr[i - 1].month) <= 0,
+      );
+      expect(isSorted).toBe(true);
+    });
+  });
+
+  // EDGE CASES
+  describe("Edge cases", () => {
+    it("should handle empty data from repository", async () => {
+      // Arrange
+      mockRepository.getMonthlyRequestCounts = jest.fn().mockResolvedValue([]);
+
+      // Act
+      const result = await service.getMonthlyRequestCounts();
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data).toHaveLength(12); // Still returns 12 months
+
+      // All months should have zero counts
+      result.data.forEach((month) => {
+        expect(month.MAINTENANCE).toBe(0);
+        expect(month.CALIBRATION).toBe(0);
+      });
+    });
+
+    it("should handle null values in data from repository", async () => {
+      // Arrange
+      const mockRawData = [
+        { month: "2025-05", MAINTENANCE: null, CALIBRATION: 5 },
+        { month: "2025-03", MAINTENANCE: 8, CALIBRATION: null },
+      ] as unknown as MonthlyDataRecord[];
+
+      mockRepository.getMonthlyRequestCounts = jest
+        .fn()
+        .mockResolvedValue(mockRawData);
+
+      // Act
+      const result = await service.getMonthlyRequestCounts();
+
+      // Assert
+      const mayData = result.data.find((d) => d.month === "2025-05");
+      expect(mayData!.MAINTENANCE).toBe(0); // Null should be converted to 0
+      expect(mayData!.CALIBRATION).toBe(5);
+
+      const marchData = result.data.find((d) => d.month === "2025-03");
+      expect(marchData!.MAINTENANCE).toBe(8);
+      expect(marchData!.CALIBRATION).toBe(0); // Null should be converted to 0
+    });
+
+    it("should ignore data for months outside the last 12 months", async () => {
+      // Arrange
+      const mockRawData: MonthlyDataRecord[] = [
+        { month: "2025-05", MAINTENANCE: 10, CALIBRATION: 5 },
+        { month: "2024-01", MAINTENANCE: 15, CALIBRATION: 7 }, // Outside last 12 months
+      ];
+
+      mockRepository.getMonthlyRequestCounts = jest
+        .fn()
+        .mockResolvedValue(mockRawData);
+
+      // Act
+      const result = await service.getMonthlyRequestCounts();
+
+      // Assert
+      // May data should be included
+      const mayData = result.data.find((d) => d.month === "2025-05");
+      expect(mayData!.MAINTENANCE).toBe(10);
+      expect(mayData!.CALIBRATION).toBe(5);
+
+      // Only months within the last 12 should be present
+      const months = result.data.map((d) => d.month);
+      expect(months).not.toContain("2024-01");
+
+      // Verify we still have exactly 12 months of data
+      expect(result.data).toHaveLength(12);
+    });
+  });
+
+  // NEGATIVE CASES
+  describe("Negative cases", () => {
+    it("should propagate errors from repository", async () => {
+      // Arrange
+      const mockError = new Error("Database error");
+      mockRepository.getMonthlyRequestCounts = jest
+        .fn()
+        .mockRejectedValue(mockError);
+
+      // Act & Assert
+      await expect(service.getMonthlyRequestCounts()).rejects.toThrow(
+        "Database error",
+      );
+      expect(mockRepository.getMonthlyRequestCounts).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle invalid data format from repository", async () => {
+      // Arrange
+      // @ts-ignore - Deliberately passing invalid data for testing
+      mockRepository.getMonthlyRequestCounts = jest.fn().mockResolvedValue([
+        { month: "2025-05", INVALID: 10 }, // Missing required properties
+      ]);
+
+      // Act
+      const result = await service.getMonthlyRequestCounts();
+
+      // Assert
+      // Should still return 12 months with proper structure
+      expect(result.data).toHaveLength(12);
+
+      // May data should have zeros for maintenance and calibration
+      const mayData = result.data.find((d) => d.month === "2025-05");
+      expect(mayData!.MAINTENANCE).toBe(0);
+      expect(mayData!.CALIBRATION).toBe(0);
+    });
+  });
+});

--- a/__tests__/unit/services/report/get-monthly-requests-report.service.unit.test.ts
+++ b/__tests__/unit/services/report/get-monthly-requests-report.service.unit.test.ts
@@ -100,6 +100,44 @@ describe("ReportService - getMonthlyRequestCounts", () => {
       });
     });
 
+    it("should throw error when repository returns non-array data", async () => {
+      // Arrange
+      // @ts-ignore - Deliberately returning non-array data for testing
+      mockRepository.getMonthlyRequestCounts = jest.fn().mockResolvedValue({
+        notAnArray: true,
+      });
+
+      // Act & Assert
+      await expect(service.getMonthlyRequestCounts()).rejects.toThrow(
+        "Data input tidak valid: harap berikan array data bulanan",
+      );
+      expect(mockRepository.getMonthlyRequestCounts).toHaveBeenCalledTimes(1);
+    });
+
+    it("should throw error when repository returns null", async () => {
+      // Arrange
+      mockRepository.getMonthlyRequestCounts = jest
+        .fn()
+        .mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(service.getMonthlyRequestCounts()).rejects.toThrow(
+        "Data input tidak valid: harap berikan array data bulanan",
+      );
+    });
+
+    it("should throw error when repository returns undefined", async () => {
+      // Arrange
+      mockRepository.getMonthlyRequestCounts = jest
+        .fn()
+        .mockResolvedValue(undefined);
+
+      // Act & Assert
+      await expect(service.getMonthlyRequestCounts()).rejects.toThrow(
+        "Data input tidak valid: harap berikan array data bulanan",
+      );
+    });
+
     it("should handle null values in data from repository", async () => {
       // Arrange
       const mockRawData = [

--- a/src/controllers/report.controller.ts
+++ b/src/controllers/report.controller.ts
@@ -1,0 +1,30 @@
+import { Request, Response, NextFunction } from "express";
+import ReportService from "../services/report.service";
+
+export class ReportController {
+  private readonly reportService: ReportService;
+
+  constructor() {
+    this.reportService = new ReportService();
+  }
+
+  public getMonthlyRequestCounts = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const result = await this.reportService.getMonthlyRequestCounts();
+
+      res.status(200).json({
+        success: true,
+        message: "Monthly request counts retrieved successfully",
+        data: result.data,
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+export default ReportController;

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import helmet from "helmet";
 // Import routes
 import userRoutes from "./routes/user.route";
 import authRoutes from "./routes/auth.route";
+import reportRoutes from "./routes/report.route";
 import sparepartRoutes from "./routes/sparepart.route";
 import divisionRoutes from "./routes/division.route";
 import commentRoutes from "./routes/comment.route";
@@ -115,6 +116,7 @@ app.use("/medical-equipment", [
   calibrationHistoryRoutes,
   partsHistoryRoutes,
 ]);
+app.use("/report", reportRoutes);
 
 // Error handling
 Sentry.setupExpressErrorHandler(app);

--- a/src/interfaces/report.interface.ts
+++ b/src/interfaces/report.interface.ts
@@ -1,0 +1,10 @@
+export interface MonthlyTypeCount {
+  MAINTENANCE: number;
+  CALIBRATION: number;
+}
+
+export interface MonthlyDataRecord {
+  month: string;
+  MAINTENANCE: number;
+  CALIBRATION: number;
+}

--- a/src/repository/report.repository.ts
+++ b/src/repository/report.repository.ts
@@ -1,0 +1,57 @@
+import { PrismaClient } from "@prisma/client";
+import prisma from "../configs/db.config";
+import {
+  MonthlyDataRecord,
+  MonthlyTypeCount,
+} from "../interfaces/report.interface";
+
+class ReportRepository {
+  private readonly prisma: PrismaClient;
+
+  constructor() {
+    this.prisma = prisma;
+  }
+
+  // Get all requests with their creation date and type
+  public async getMonthlyRequestCounts(): Promise<MonthlyDataRecord[]> {
+    const requests = await this.prisma.request.findMany({
+      select: {
+        createdOn: true,
+        requestType: true,
+      },
+      where: {
+        createdOn: {
+          not: null,
+        },
+      },
+    });
+
+    const monthlyData: Record<string, MonthlyTypeCount> = {};
+
+    requests.forEach((request) => {
+      if (!request.createdOn) return;
+
+      const date = new Date(request.createdOn);
+      const yearMonth = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+
+      monthlyData[yearMonth] ??= {
+        MAINTENANCE: 0,
+        CALIBRATION: 0,
+      };
+
+      if (
+        request.requestType === "MAINTENANCE" ||
+        request.requestType === "CALIBRATION"
+      ) {
+        monthlyData[yearMonth][request.requestType]++;
+      }
+    });
+
+    return Object.entries(monthlyData).map(([month, counts]) => ({
+      month,
+      ...counts,
+    }));
+  }
+}
+
+export default ReportRepository;

--- a/src/routes/report.route.ts
+++ b/src/routes/report.route.ts
@@ -1,0 +1,15 @@
+import { Router } from "express";
+import ReportController from "../controllers/report.controller";
+import verifyToken from "../middleware/verifyToken";
+import authorizeRoles from "../middleware/authorizeRole";
+
+const router = Router();
+const controller = new ReportController();
+
+// Middleware
+router.use(verifyToken, authorizeRoles("Admin", "Fasum"));
+
+// Routes
+router.get("/monthly-requests", controller.getMonthlyRequestCounts);
+
+export default router;

--- a/src/services/report.service.ts
+++ b/src/services/report.service.ts
@@ -1,0 +1,56 @@
+import { MonthlyDataRecord } from "../interfaces/report.interface";
+import ReportRepository from "../repository/report.repository";
+import { getJakartaTime } from "../utils/date.utils";
+
+class ReportService {
+  private readonly reportRepository: ReportRepository;
+
+  constructor() {
+    this.reportRepository = new ReportRepository();
+  }
+
+  public async getMonthlyRequestCounts() {
+    const rawData = await this.reportRepository.getMonthlyRequestCounts();
+    const result = this.ensureLast12Months(rawData);
+
+    return {
+      success: true,
+      data: result,
+    };
+  }
+
+  private ensureLast12Months(
+    rawData: MonthlyDataRecord[],
+  ): MonthlyDataRecord[] {
+    const currentDate = getJakartaTime();
+    const monthsData: Record<string, MonthlyDataRecord> = {};
+
+    // Inisialisasi data untuk 12 bulan terakhir dengan nol
+    for (let i = 0; i < 12; i++) {
+      const date = new Date(currentDate);
+      date.setMonth(date.getMonth() - i);
+      const yearMonth = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+
+      monthsData[yearMonth] = {
+        month: yearMonth,
+        MAINTENANCE: 0,
+        CALIBRATION: 0,
+      };
+    }
+
+    // Update data dengan nilai dari data asli
+    rawData.forEach((item) => {
+      if (monthsData[item.month]) {
+        monthsData[item.month].MAINTENANCE = item.MAINTENANCE ?? 0;
+        monthsData[item.month].CALIBRATION = item.CALIBRATION ?? 0;
+      }
+    });
+
+    // Convert kembali ke array dan diurutkan berdasarkan bulan (newest first)
+    return Object.values(monthsData).sort((a, b) =>
+      b.month.localeCompare(a.month),
+    );
+  }
+}
+
+export default ReportService;

--- a/src/services/report.service.ts
+++ b/src/services/report.service.ts
@@ -22,6 +22,12 @@ class ReportService {
   private ensureLast12Months(
     rawData: MonthlyDataRecord[],
   ): MonthlyDataRecord[] {
+    if (!Array.isArray(rawData)) {
+      throw new Error(
+        "Data input tidak valid: harap berikan array data bulanan",
+      );
+    }
+
     const currentDate = getJakartaTime();
     const monthsData: Record<string, MonthlyDataRecord> = {};
 

--- a/src/services/report.service.ts
+++ b/src/services/report.service.ts
@@ -9,7 +9,10 @@ class ReportService {
     this.reportRepository = new ReportRepository();
   }
 
-  public async getMonthlyRequestCounts() {
+  public async getMonthlyRequestCounts(): Promise<{
+    success: boolean;
+    data: MonthlyDataRecord[];
+  }> {
     const rawData = await this.reportRepository.getMonthlyRequestCounts();
     const result = this.ensureLast12Months(rawData);
 


### PR DESCRIPTION
# Monthly Requests Report

closes #121 

URL:
- **GET** `/laporan/monthly-requests`

## Summary
- **Monthly Requests Report** : Implemented Monthly Requests Report to get all last 12 months requests (Maintenance and Calibration)

## Next Steps
- Integrate backend and design frontend graphics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint to retrieve monthly counts of maintenance and calibration requests, accessible to authorized users.
  - Added data normalization to ensure consistent 12-month reporting, even when some months have no data.

- **Bug Fixes**
  - Improved error handling for invalid or missing data in report generation.

- **Tests**
  - Added comprehensive unit tests for controller, service, and repository layers related to monthly request reporting.

- **Documentation**
  - Defined new interfaces for structured reporting data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->