### PR TITLE
Chore/Fix Divisi Bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "*"
+      - "chore/*" # Delete this later
     
 
 jobs:

--- a/__tests__/unit/repository/division/add-division.repository.unit.test.tsx
+++ b/__tests__/unit/repository/division/add-division.repository.unit.test.tsx
@@ -62,6 +62,47 @@ describe("DivisionRepository - ADD", () => {
     );
   });
 
+  // New tests for name validation
+  it("should throw an error when adding a division with only whitespace in name", async () => {
+    const addData: Partial<DivisionDTO> = {
+      divisi: "    ", // Only whitespace
+      parentId: 1,
+    };
+
+    await expect(divisionRepository.addDivision(addData)).rejects.toThrow(
+      "Division name cannot be empty or contain only whitespace",
+    );
+
+    // Verify that the create method was never called
+    expect(mockPrisma.create).not.toHaveBeenCalled();
+  });
+
+  it("should throw an error when adding a division with empty string name", async () => {
+    const addData: Partial<DivisionDTO> = {
+      divisi: "",
+      parentId: 1,
+    };
+
+    await expect(divisionRepository.addDivision(addData)).rejects.toThrow(
+      "Division name cannot be empty or contain only whitespace",
+    );
+
+    expect(mockPrisma.create).not.toHaveBeenCalled();
+  });
+
+  it("should throw an error when adding a division with null name", async () => {
+    const addData: Partial<DivisionDTO> = {
+      divisi: null,
+      parentId: 1,
+    };
+
+    await expect(divisionRepository.addDivision(addData)).rejects.toThrow(
+      "Division name cannot be empty or contain only whitespace",
+    );
+
+    expect(mockPrisma.create).not.toHaveBeenCalled();
+  });
+
   it("should get divisi by id", async () => {
     const mockNewDivision: DivisionDTO = {
       id: 2,

--- a/__tests__/unit/repository/division/update-division.repository.unit.test.tsx
+++ b/__tests__/unit/repository/division/update-division.repository.unit.test.tsx
@@ -44,6 +44,38 @@ describe("DivisionRepository - UPDATE", () => {
       expect(result).toEqual(updatedDivision);
     });
 
+    // New tests for name validation
+    it("should throw an error when updating a division with only whitespace in name", async () => {
+      await expect(
+        divisionRepository.updateDivision(1, { divisi: "    " }),
+      ).rejects.toThrow(
+        "Division name cannot be empty or contain only whitespace",
+      );
+
+      // Verify that the update method was never called
+      expect(prisma.listDivisi.update).not.toHaveBeenCalled();
+    });
+
+    it("should throw an error when updating a division with empty string name", async () => {
+      await expect(
+        divisionRepository.updateDivision(1, { divisi: "" }),
+      ).rejects.toThrow(
+        "Division name cannot be empty or contain only whitespace",
+      );
+
+      expect(prisma.listDivisi.update).not.toHaveBeenCalled();
+    });
+
+    it("should throw an error when updating a division with null name", async () => {
+      await expect(
+        divisionRepository.updateDivision(1, { divisi: null }),
+      ).rejects.toThrow(
+        "Division name cannot be empty or contain only whitespace",
+      );
+
+      expect(prisma.listDivisi.update).not.toHaveBeenCalled();
+    });
+
     it("should throw a 404 error if the division is not found (P2025)", async () => {
       // Create a mock Prisma error with P2025 code
       const prismaError = new Prisma.PrismaClientKnownRequestError(

--- a/src/repository/division.repository.ts
+++ b/src/repository/division.repository.ts
@@ -9,7 +9,19 @@ class DivisionRepository {
     this.prisma = prisma;
   }
 
+  private validateDivisionName(name?: string | null): void {
+    if (!name || name.trim() === "") {
+      throw new Error(
+        "Division name cannot be empty or contain only whitespace",
+      );
+    }
+  }
+
   public async addDivision(data: Partial<DivisionDTO>): Promise<DivisionDTO> {
+    if (data.divisi !== undefined) {
+      this.validateDivisionName(data.divisi);
+    }
+
     return await this.prisma.listDivisi.create({ data });
   }
 
@@ -113,6 +125,10 @@ class DivisionRepository {
     data: Prisma.ListDivisiUpdateInput,
   ): Promise<DivisionDTO> {
     try {
+      if (data.divisi !== undefined) {
+        this.validateDivisionName(data.divisi as string | null);
+      }
+
       return await this.prisma.listDivisi.update({
         where: { id },
         data,

--- a/src/repository/division.repository.ts
+++ b/src/repository/division.repository.ts
@@ -29,18 +29,10 @@ class DivisionRepository {
     return await this.prisma.listDivisi.findUnique({ where: { id } });
   }
 
-  /**
-   * Get all divisions without hierarchy
-   */
   public async getAllDivisions(): Promise<DivisionDTO[]> {
     return await this.prisma.listDivisi.findMany();
   }
 
-  /**
-   * Get hierarchical division structure (root divisions with their children)
-   * This formats the data for tree display in the frontend
-   * Uses a bottom-up approach to build the hierarchy
-   */
   public async getDivisionsHierarchy(): Promise<DivisionWithChildrenDTO[]> {
     // Ambil semua divisions dari database dalam satu query
     const allDivisions = await this.prisma.listDivisi.findMany({
@@ -77,9 +69,6 @@ class DivisionRepository {
     return rootDivisions;
   }
 
-  /**
-   * Get a specific division with its children
-   */
   public async getDivisionWithChildren(
     id: number,
   ): Promise<DivisionWithChildrenDTO | null> {
@@ -91,18 +80,12 @@ class DivisionRepository {
     });
   }
 
-  /**
-   * Get divisions based on filter criteria
-   */
   public async getFilteredDivisions(
     whereClause: Prisma.ListDivisiWhereInput,
   ): Promise<DivisionDTO[]> {
     return await this.prisma.listDivisi.findMany({ where: whereClause });
   }
 
-  /**
-   * Get divisions with user count
-   */
   public async getDivisionsWithUserCount(): Promise<
     Array<DivisionDTO & { userCount: number }>
   > {


### PR DESCRIPTION
URL :  
- POST `/divisi`
- PUT `/divisi/:id`

## Summary
- Fixed case where `divisi` name field can accept only whitespaces on creating and updating a division name field.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for division names to prevent empty or whitespace-only values when adding or updating divisions. Users will now receive an error if invalid division names are provided.

- **Tests**
  - Added new test cases to ensure division name validation works correctly for empty, whitespace, or null values.

- **Chores**
  - Updated CI workflow configuration with a temporary branch pattern for triggering builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->